### PR TITLE
Security: Mitigate username enumeration and timing attacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - Timing Attacks in Authentication
+**Vulnerability:** The login functions (for Admin, Connect/Clients, and APIs) were returning different messages for "User not found" and "Incorrect password". More importantly, they were executing `password_verify` only if the user was found. This introduces timing side-channels, as checking a non-existent user takes significantly less time than checking an existing user due to the heavy bcrypt operation. This allowed an attacker to enumerate usernames.
+**Learning:** To mitigate timing attacks, it's crucial that both success and failure paths take a roughly equivalent amount of time. If a user is not found, a dummy `password_verify` with a static hash should be executed to consume CPU time equivalent to checking a real password.
+**Prevention:** Always normalize error messages (e.g., "Invalid credentials") and ensure that computationally expensive operations like `password_verify` are performed unconditionally, using a dummy string/hash when the target is missing.

--- a/application/controllers/Login.php
+++ b/application/controllers/Login.php
@@ -59,7 +59,11 @@ class Login extends CI_Controller
                     echo json_encode($json);
                 }
             } else {
-                $json = ['result' => false, 'message' => 'Usuário não encontrado, verifique se suas credenciais estão corretass.', 'MAPOS_TOKEN' => $this->security->get_csrf_hash()];
+                // Simulate password_verify to mitigate timing attacks and username enumeration
+                $dummy_hash = '$2y$10$dummyhashdummyhashdummyhashdummyhashdummyhashdummyhas';
+                password_verify($password, $dummy_hash);
+
+                $json = ['result' => false, 'message' => 'Os dados de acesso estão incorretos.', 'MAPOS_TOKEN' => $this->security->get_csrf_hash()];
                 echo json_encode($json);
             }
         }

--- a/application/controllers/Mine.php
+++ b/application/controllers/Mine.php
@@ -266,7 +266,11 @@ class Mine extends CI_Controller
                     echo json_encode(['result' => false, 'message' => 'Os dados de acesso estão incorretos.', 'MAPOS_TOKEN' => $this->security->get_csrf_hash()]);
                 }
             } else {
-                echo json_encode(['result' => false, 'message' => 'Usuário não encontrado, verifique se suas credenciais estão corretas.', 'MAPOS_TOKEN' => $this->security->get_csrf_hash()]);
+                // Simulate password_verify to mitigate timing attacks and username enumeration
+                $dummy_hash = '$2y$10$dummyhashdummyhashdummyhashdummyhashdummyhashdummyhas';
+                password_verify($password, $dummy_hash);
+
+                echo json_encode(['result' => false, 'message' => 'Os dados de acesso estão incorretos.', 'MAPOS_TOKEN' => $this->security->get_csrf_hash()]);
             }
         }
     }

--- a/application/controllers/api/v1/UsuariosController.php
+++ b/application/controllers/api/v1/UsuariosController.php
@@ -298,6 +298,10 @@ class UsuariosController extends REST_Controller
             ], REST_Controller::HTTP_UNAUTHORIZED);
         }
 
+        // Simulate password_verify to mitigate timing attacks and username enumeration
+        $dummy_hash = '$2y$10$dummyhashdummyhashdummyhashdummyhashdummyhashdummyhas';
+        password_verify($password, $dummy_hash);
+
         $this->response([
             'status' => false,
             'message' => 'Os dados de acesso estão incorretos!',
@@ -339,7 +343,7 @@ class UsuariosController extends REST_Controller
 
             $this->response([
                 'status' => false,
-                'message' => 'Usuário não encontrado, verifique se suas credenciais estão corretas!',
+                'message' => 'Os dados de acesso estão incorretos!',
             ], REST_Controller::HTTP_UNAUTHORIZED);
         }
 

--- a/application/controllers/api/v1/client/ClientLoginController.php
+++ b/application/controllers/api/v1/client/ClientLoginController.php
@@ -32,9 +32,13 @@ class ClientLoginController extends REST_Controller
         $cliente = $this->check_credentials($email);
 
         if (!$cliente) {
+            // Simulate password_verify to mitigate timing attacks and username enumeration
+            $dummy_hash = '$2y$10$dummyhashdummyhashdummyhashdummyhashdummyhashdummyhas';
+            password_verify($password, $dummy_hash);
+
             $this->response([
                 'result' => false,
-                 'message' => 'Usuário não encontrado.'
+                 'message' => 'Os dados de acesso estão incorretos.'
                 ], REST_Controller::HTTP_UNAUTHORIZED);
             return;
         }


### PR DESCRIPTION
This change improves the security of the application's authentication flows. By replacing specific "User not found" messages with generic "Invalid credentials" messages, we prevent attackers from enumerating valid usernames. Furthermore, by introducing a dummy `password_verify` execution when a user is not found, we normalize the response time for both successful and unsuccessful login attempts, mitigating timing attacks that could otherwise be used to infer the existence of a user.

---
*PR created automatically by Jules for task [1991321859301721256](https://jules.google.com/task/1991321859301721256) started by @cezargf*