### PR TITLE
refactor: eliminate database queries and business logic from views

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-16 - Removed N+1 DB Queries from Views
+**Vulnerability:** Views in MapOS were executing database queries in a loop, causing an N+1 query vulnerability that severely degraded performance. Specifically, `isEditable` model methods calling `getById` were being used on each row rendered in the view.
+**Learning:** Performance issues in MVC architectures frequently result from failing to eager load data or from checking authorization directly on each row in the view via database lookup instead of computing properties in memory.
+**Prevention:** Data required for conditional rendering must be fetched fully via JOIN or bulk evaluation in the controller. Avoid calling model functions that trigger SQL queries inside view iteration blocks.

--- a/application/controllers/Mapos.php
+++ b/application/controllers/Mapos.php
@@ -31,6 +31,14 @@ class Mapos extends MY_Controller
         $this->data['menuPainel'] = 'Painel';
         $this->data['view'] = 'mapos/painel';
 
+        // Count queries for painel
+        $this->data['count_clientes'] = $this->db->count_all('clientes');
+        $this->data['count_produtos'] = $this->db->count_all('produtos');
+        $this->data['count_servicos'] = $this->db->count_all('servicos');
+        $this->data['count_os'] = $this->db->count_all('os');
+        $this->data['count_garantias'] = $this->db->count_all('garantias');
+        $this->data['count_vendas'] = $this->db->count_all('vendas');
+
         return $this->layout();
     }
 

--- a/application/controllers/Os.php
+++ b/application/controllers/Os.php
@@ -298,6 +298,10 @@ class Os extends MY_Controller
         $this->load->model('mapos_model');
         $this->data['emitente'] = $this->mapos_model->getEmitente();
 
+        $this->data['zapnumber'] = preg_replace("/[^0-9]/", "", $this->data['result']->celular_cliente);
+        $troca = [$this->data['result']->nomeCliente, $this->data['result']->idOs, $this->data['result']->status, 'R$ ' . ($this->data['result']->desconto != 0 && $this->data['result']->valor_desconto != 0 ? number_format($this->data['result']->valor_desconto, 2, ',', '.') : number_format($this->data['totalProdutos'] + $this->data['totalServico'], 2, ',', '.')), strip_tags($this->data['result']->descricaoProduto), ($this->data['emitente'] ? $this->data['emitente']->nome : ''), ($this->data['emitente'] ? $this->data['emitente']->telefone : ''), strip_tags($this->data['result']->observacoes), strip_tags($this->data['result']->defeito), strip_tags($this->data['result']->laudoTecnico), date('d/m/Y', strtotime($this->data['result']->dataFinal)), date('d/m/Y', strtotime($this->data['result']->dataInicial)), $this->data['result']->garantia . ' dias'];
+        $this->data['texto_de_notificacao'] = $this->os_model->criarTextoWhats($this->data['texto_de_notificacao'], $troca);
+
         $this->data['view'] = 'os/editarOs';
 
         return $this->layout();
@@ -346,6 +350,10 @@ class Os extends MY_Controller
             $this->data['totalServico'] = $return['totalServico'];
             $this->data['totalProdutos'] = $return['totalProdutos'];
         }
+
+        $this->data['zapnumber'] = preg_replace("/[^0-9]/", "", $this->data['result']->celular_cliente);
+        $troca = [$this->data['result']->nomeCliente, $this->data['result']->idOs, $this->data['result']->status, 'R$ ' . ($this->data['result']->desconto != 0 && $this->data['result']->valor_desconto != 0 ? number_format($this->data['result']->valor_desconto, 2, ',', '.') : number_format((isset($this->data['totalProdutos']) ? $this->data['totalProdutos'] : 0) + (isset($this->data['totalServico']) ? $this->data['totalServico'] : 0), 2, ',', '.')), strip_tags($this->data['result']->descricaoProduto), ($this->data['emitente'] ? $this->data['emitente']->nome : ''), ($this->data['emitente'] ? $this->data['emitente']->telefone : ''), strip_tags($this->data['result']->observacoes), strip_tags($this->data['result']->defeito), strip_tags($this->data['result']->laudoTecnico), date('d/m/Y', strtotime($this->data['result']->dataFinal)), date('d/m/Y', strtotime($this->data['result']->dataInicial)), $this->data['result']->garantia . ' dias'];
+        $this->data['texto_de_notificacao'] = $this->os_model->criarTextoWhats($this->data['texto_de_notificacao'], $troca);
 
         return $this->layout();
     }

--- a/application/views/mapos/painel.php
+++ b/application/views/mapos/painel.php
@@ -151,7 +151,7 @@
                     <a href="<?php echo base_url(); ?>index.php/clientes/adicionar" class="card tip-top" title="Add Clientes e Fornecedores">
                         <div><i class='bx bxs-group iconBx'></i></div>
                         <div>
-                            <div class="cardName2"><?= $this->db->count_all('clientes'); ?></div>
+                            <div class="cardName2"><?= $count_clientes ?></div>
                             <div class="cardName">Clientes</div>
                         </div>
                     </a>
@@ -159,7 +159,7 @@
                     <a href="<?php echo base_url(); ?>index.php/produtos/adicionar" class="card tip-top" title="Adicionar Produtos">
                         <div><i class='bx bxs-package iconBx2'></i></div>
                         <div>
-                            <div class="cardName2"><?= $this->db->count_all('produtos'); ?></div>
+                            <div class="cardName2"><?= $count_produtos ?></div>
                             <div class="cardName">Produtos</div>
                         </div>
                     </a>
@@ -167,7 +167,7 @@
                     <a href="<?php echo base_url() ?>index.php/servicos/adicionar" class="card tip-top" title="Adicionar serviços">
                         <div><i class='bx bxs-stopwatch iconBx3'></i></div>
                         <div>
-                            <div class="cardName2"><?= $this->db->count_all('servicos'); ?></div>
+                            <div class="cardName2"><?= $count_servicos ?></div>
                             <div class="cardName">Serviços</div>
                         </div>
                     </a>
@@ -175,7 +175,7 @@
                     <a href="<?php echo base_url(); ?>index.php/os/adicionar" class="card tip-top" title="Adicionar OS">
                         <div><i class='bx bxs-spreadsheet iconBx4'></i></div>
                         <div>
-                            <div class="cardName2"><?= $this->db->count_all('os'); ?></div>
+                            <div class="cardName2"><?= $count_os ?></div>
                             <div class="cardName">Ordens</div>
                         </div>
                     </a>
@@ -183,7 +183,7 @@
                     <a href="<?php echo base_url(); ?>index.php/garantias" class="card tip-top" title="Adicionar garantia">
                         <div><i class='bx bxs-receipt iconBx6'></i></div>
                         <div>
-                            <div class="cardName2"><?= $this->db->count_all('garantias'); ?></div>
+                            <div class="cardName2"><?= $count_garantias ?></div>
                             <div class="cardName">Garantias</div>
                         </div>
                     </a>
@@ -191,7 +191,7 @@
                     <a href="<?php echo base_url() ?>index.php/vendas/adicionar" class="card tip-top" title="Adicionar Vendas">
                         <div><i class='bx bxs-cart-alt iconBx5'></i></div>
                         <div>
-                            <div class="cardName2"><?= $this->db->count_all('vendas'); ?></div>
+                            <div class="cardName2"><?= $count_vendas ?></div>
                             <div class="cardName">Vendas</div>
                         </div>
                     </a>

--- a/application/views/os/editarOs.php
+++ b/application/views/os/editarOs.php
@@ -42,10 +42,6 @@
                         </div>
                     </div>
                     <?php if ($this->permission->checkPermission($this->session->userdata('permissao'), 'eOs')) {
-                        $this->load->model('os_model');
-                        $zapnumber = preg_replace("/[^0-9]/", "", $result->celular_cliente);
-                        $troca = [$result->nomeCliente, $result->idOs, $result->status, 'R$ ' . ($result->desconto != 0 && $result->valor_desconto != 0 ? number_format($result->valor_desconto, 2, ',', '.') : number_format($totalProdutos + $totalServico, 2, ',', '.')), strip_tags($result->descricaoProduto), ($emitente ? $emitente->nome : ''), ($emitente ? $emitente->telefone : ''), strip_tags($result->observacoes), strip_tags($result->defeito), strip_tags($result->laudoTecnico), date('d/m/Y', strtotime($result->dataFinal)), date('d/m/Y', strtotime($result->dataInicial)), $result->garantia . ' dias'];
-                        $texto_de_notificacao = $this->os_model->criarTextoWhats($texto_de_notificacao, $troca);
                         if (!empty($zapnumber)) {
                             echo '<a title="Via WhatsApp" class="button btn btn-mini btn-success" id="enviarWhatsApp" target="_blank" href="https://wa.me/send?phone=55' . $zapnumber . '&text=' . $texto_de_notificacao . '" ' . ($zapnumber == '' ? 'disabled' : '') . '>
                                 <span class="button__icon"><i class="bx bxl-whatsapp"></i></span> <span class="button__text">WhatsApp</span>

--- a/application/views/os/os.php
+++ b/application/views/os/os.php
@@ -163,7 +163,8 @@ foreach ($results as $r) {
     echo '<td><span class="badge" style="background-color: ' . $cor . '; border-color: ' . $cor . '">' . $r->status . '</span> </td>';
     echo '<td>';
 
-    $editavel = $this->os_model->isEditable($r->idOs);
+    $osT = (int) ($r->status === 'Faturado' || $r->status === 'Cancelado' || $r->faturado == 1);
+    $editavel = $osT ? $configuration['control_editos'] == '1' : true;
 
     if ($this->permission->checkPermission($this->session->userdata('permissao'), 'vOs')) {
         echo '<a style="margin-right: 1%" href="' . base_url() . 'index.php/os/visualizar/' . $r->idOs . '" class="btn-nwe" title="Ver mais detalhes"><i class="bx bx-show"></i></a>';

--- a/application/views/os/visualizarOs.php
+++ b/application/views/os/visualizarOs.php
@@ -28,10 +28,6 @@
                     </div>
 
                     <?php if ($this->permission->checkPermission($this->session->userdata('permissao'), 'vOs')) {
-                        $this->load->model('os_model');
-                        $zapnumber = preg_replace("/[^0-9]/", "", $result->celular_cliente);
-                        $troca = [$result->nomeCliente, $result->idOs, $result->status, 'R$ ' . ($result->desconto != 0 && $result->valor_desconto != 0 ? number_format($result->valor_desconto, 2, ',', '.') : number_format($totalProdutos + $totalServico, 2, ',', '.')), strip_tags($result->descricaoProduto), ($emitente ? $emitente->nome : ''), ($emitente ? $emitente->telefone : ''), strip_tags($result->observacoes), strip_tags($result->defeito), strip_tags($result->laudoTecnico), date('d/m/Y', strtotime($result->dataFinal)), date('d/m/Y', strtotime($result->dataInicial)), $result->garantia . ' dias'];
-                        $texto_de_notificacao = $this->os_model->criarTextoWhats($texto_de_notificacao, $troca);
                         if (!empty($zapnumber)) {
                             echo '<a title="Enviar Por WhatsApp" class="button btn btn-mini btn-success" id="enviarWhatsApp" target="_blank" href="https://api.whatsapp.com/send?phone=55' . $zapnumber . '&text=' . $texto_de_notificacao . '">
                                 <span class="button__icon"><i class="bx bxl-whatsapp"></i></span> <span class="button__text">WhatsApp</span>

--- a/application/views/vendas/vendas.php
+++ b/application/views/vendas/vendas.php
@@ -139,7 +139,7 @@
                 echo '<a style="margin-right: 1%" href="' . base_url() . 'index.php/vendas/imprimirTermica/' . $r->idVendas . '" target="_blank" class="btn-nwe6" title="Imprimir Não Fiscal"><i class="bx bx-printer bx-xs"></i></a>';
             }
 
-            $editavel = $this->vendas_model->isEditable($r->idVendas);
+            $editavel = $r->faturado ? $configuration['control_edit_vendas'] == '1' : true;
 
             if ($r->faturado != 1 || $editavel) {
                 if ($this->permission->checkPermission($this->session->userdata('permissao'), 'eVenda')) {

--- a/application/views/vendas/visualizarVenda.php
+++ b/application/views/vendas/visualizarVenda.php
@@ -5,7 +5,7 @@
             <div class="widget-title" style="margin: 10px 0 0">
                     <div class="buttons">
                         <?php
-                        $editavel = $this->vendas_model->isEditable($result->idVendas);
+                        $editavel = $result->faturado ? $configuration['control_edit_vendas'] == '1' : true;
 if (($result->faturado != 1 || $editavel) && $this->permission->checkPermission($this->session->userdata('permissao'), 'eVenda')): ?>
                             <a title="Editar Venda" class="button btn btn-mini btn-success" href="<?php echo base_url() . 'index.php/vendas/editar/' . $result->idVendas; ?>">
                                 <span class="button__icon"><i class="bx bx-edit"></i></span>


### PR DESCRIPTION
This pull request refactors several view files to improve performance and adhere to MVC patterns. Views were making direct database queries or calling model logic inside loops, causing N+1 query inefficiencies.

Key changes:
- `painel.php`: `count_all` database calls were moved to the `Mapos` controller.
- `os.php` & `vendas.php`: Removed `isEditable` model method calls inside loops, replacing them with in-memory checks using loop variables and the automatically injected global configuration (`$configuration['control_editos']`, `$configuration['control_edit_vendas']`).
- `visualizarOs.php` & `editarOs.php`: Shifted the generation of `$texto_de_notificacao` and `$zapnumber` to the controller where data formatting belongs.

---
*PR created automatically by Jules for task [2373530467167720773](https://jules.google.com/task/2373530467167720773) started by @cezargf*