### PR TITLE
Update rodape.php

### DIFF
--- a/application/views/tema/rodape.php
+++ b/application/views/tema/rodape.php
@@ -14,6 +14,7 @@
         var dataTableEnabled = '<?= $configuration['control_datatable'] ?>';
         if(dataTableEnabled == '1') {
             $('#tabela').dataTable( {
+                "pageLength": <?= $configuration['per_page'] ?>,
                 "ordering": false,
                 "info": false,
                 "language": {


### PR DESCRIPTION
Adicionar a propriedade pageLength correspondente ao valor configurado no sistema.

Ao configurar a quantidade de registros exibidos por página, quando a visualização em DataTables está ativada e configurada para exibir acima de 10 registros por página, a exibição de quantidade de registros por página nas telas de listagem não correspondem ao valor configurado.